### PR TITLE
Tab keys excluded

### DIFF
--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -85,7 +85,15 @@ trait Helpers
     {
         $fieldNames = [];
         foreach ($this->fields() as $field) {
-            if (filled($field)) $fieldNames[] = $field->name;
+            if (filled($field)){
+                if($field->type === "tab" && isset($field->fields)){
+                    foreach ($field->fields as $tabField) {
+                        $fieldNames[] = $tabField->name;
+                    }
+                } else {
+                    $fieldNames[] = $field->name;
+                }
+            }
         }
         return $fieldNames;
     }
@@ -114,7 +122,7 @@ trait Helpers
 
         foreach ($fields as &$field) {
             if (filled($field)) {
-                $fieldKey = (empty($prefix)) ? $field->key : $prefix . '.' . $field->name;
+                $fieldKey = $field->type === 'tab' ? "" : ((empty($prefix)) ? $field->key : $prefix . '.' . $field->name);
                 $field->key = $fieldKey;
                 $fieldKey = ($field->type === 'array') ? "{$fieldKey}.*" : $fieldKey;
                 if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {

--- a/src/Traits/ValidatesFields.php
+++ b/src/Traits/ValidatesFields.php
@@ -22,7 +22,7 @@ trait ValidatesFields
             if (filled($field)) {
                 if (in_array($field->type, ['array', 'keyval', 'tab'])) {
                     if (property_exists($field, 'fields') && is_array($field->fields) && 0 < count($field->fields)) {
-                        $ruleName = $field->type === 'array' ? "{$prefix}.{$field->name}.*" : "{$prefix}.{$field->name}";
+                        $ruleName = $field->type === 'array' ? "{$prefix}.{$field->name}.*" : ($field->type === 'tab' ? "{$prefix}" : "{$prefix}.{$field->name}");
                         $rules = array_merge($rules, $this->get_rules($field->fields, $ruleName));
                     }
                     $rules["$prefix.$field->name"] = $field->rules ?? 'nullable';
@@ -50,6 +50,7 @@ trait ValidatesFields
         if ($this->labelsAsAttributes) {
             foreach ($this->getFieldsFlat() as $field) {
                 if ($field != null && $field->labelAsAttribute) {
+                    if($field->type === "tab") continue;
                     if (in_array($field->type, ['array', 'keyval', 'tab'])) {
                         foreach ($field->fields as $array_field) {
                             $key = $field->type === 'array'


### PR DESCRIPTION
In order to receive and validate form value data, there were requirements such as json data or model $cast for each tab item. With this change, these are no longer needed.

```php
Tab::make('Foo')->fields([
    Input::make('Name')->rules('required'),
    Input::make('Price')->rules('required|min:5'),
]),
Tab::make('Foo 2')->fields([
    Input::make('Price 2')->rules('required'),
]),
```
**Before:**
`form_data.foo.name`
`form_data.foo.price`
`form_data.foo2.price2`

![tabs1](https://user-images.githubusercontent.com/13007665/102611425-effccf80-413f-11eb-862d-5ccf4fa5ab8a.gif)

**After:**
`form_data.name`
`form_data.price`
`form_data.price2`

![tabs2](https://user-images.githubusercontent.com/13007665/102611419-ec694880-413f-11eb-8623-b6c0447c8f96.gif)

_Note: The form style looks distorted since I have not adjusted my tailwind styles._